### PR TITLE
workspace-directories

### DIFF
--- a/docs/blueprint-designer-guide/blueprints/blueprints-yaml-structure.md
+++ b/docs/blueprint-designer-guide/blueprints/blueprints-yaml-structure.md
@@ -5,14 +5,14 @@ title: Blueprint YAML Structure
 
 The Torque's blueprint YAML is the main blueprint definition file. It contains general information about the environment as well as the grains that make up the environment's applications and services. The blueprint YAML is published to end-users in Torque's blueprint catalog. 
 
-### spec_version
+## spec_version
 The spec_version determines the blueprint YAML type. Currently, Torque supports spec_version:2 as the default and recommended version. With time, new preview releases and official feature releases will bring more and more features and users will be able to use other spec versions.
 
 ```yaml
 spec_version: 2
 ```
 
-### Description
+## description
 The blueprint’s description is an optional but recommended field. Blueprint description will be presented in the Torque's UI and API so users consuming environment will have more information about the blueprints to batter match their business need to the available set of blueprints published in the account catalog.
 
 
@@ -22,7 +22,7 @@ description: Performance testing deployment based on RDS, EKS and Lambda
 
 ```
 
-### Instructions
+## instructions
 
 Instructions are the recommended way for the blueprint developer to communicate with the end user and explain how to use this blueprint. The instructions can be simple text, or a complete MarkDown file, hosted in your git repository. 
 
@@ -48,7 +48,7 @@ instructions:
 :::
 
 
-### Inputs
+## inputs
 Blueprint designers can publish blueprint inputs to their end-users to add flexibility while launching a new environment from the blueprints, without altering the blueprint code itself. Input data can be later used in the blueprint to control orchestration, pass information to automation processes, and more.
 
 The input definition is composed out of the following fields: 
@@ -121,22 +121,22 @@ inputs:
 We then configure a parameter with name: aws-allowed-regions and value "us-east-1,us-east2" .
 The end user will be presented with a drop down of these 2 values as the allowed values options.
 
-### Outputs
+## outputs
 Outputs exposes information about your newly deployed environment and make it available for the environment's end-user or automation processes. Outputs will usually be available at the end of the environment's initialization and accessible throughout the environment lifecycle.
 
 Outputs are a dictionary composed by the output name and the output value.
 
 ```yaml
 outputs:
-  WebsiteUrl:
-    value: 'application-name-{{ sandboxid | downcase }}.testquali.click:8080'
+  website-url:
+    value: 'https://application-name-{{ sandboxid | downcase }}.quali.click'
+    quick: true # optional. default false
     kind: link
-    quick: true
-  DB_Hostname:
-    value: '{{ .grains.mySqlDB.outputs.hostname }}'
+  db-hostname:
+    value: '{{ .grains.mysql.outputs.hostname }}'
 ```
 
-The "quick" attribute is optional and defaults to false. Setting it to "true" will cause the specific output to be presented in the quick access section of the environment for ease of use.
+The ```quick: true``` attribute is optional and defaults to false. Setting it to `true` will cause the specific output to be presented in the __Quick Access__ section of the environment for ease of use.
 
 :::info
 The example above includes some of the Torque's YAML templating engine capabilities allowing the blueprint designer more flexibility and leads to less code that will require maintenance. More examples for templating will be described [Torque Templating engine](/blueprint-designer-guide/blueprints/blueprints-yaml-structure#torque-templating-engine).
@@ -147,7 +147,7 @@ The outputs section in the Torque blueprint YAML also supports spaces to make ou
 ```yaml
 outputs:
   Database Connection String:
-    value: '{{ .grains.mySqlDB.outputs.connection_string }}'
+    value: '{{ .grains.mysql.outputs.connection_string }}'
 ```
 
 When using outputs with spaces in a nested blueprint, make sure encase the output name in the following way:
@@ -155,18 +155,18 @@ When using outputs with spaces in a nested blueprint, make sure encase the outpu
 ```yaml
 outputs:
   Database Connection String:
-    value: '{{ .grains.mySqlDB.outputs.["Database Connection String"] }}'
+    value: '{{ .grains.mysql.outputs.["Database Connection String"] }}'
 
 grains:
   nested-bp:
     kind: blueprint
     spec: 
       outputs: 
-      - "Database Connection String"
+        - "Database Connection String"
 ```
 
 
-### Grains
+## grains
 Grains are the basic building blocks of a blueprint utilizing infrastructure as code (IaC) assets or automation processes to orchestrate the desired environment. In many organization, the blueprint designers will have a predefined set of grains they can use in blueprints provided by the IT/Ops/DevOps or platform team. 
 
 The basic grain template is composed out of the grain name, kind, inputs and output. specific grains might support other features that are technology specific.
@@ -176,7 +176,8 @@ grain_name:
     kind: terraform
     spec:
       source: 
-        path: <path to repository>
+        store: <connected repo name>
+        path: <path to module>
       agent:
         name: '{{ .inputs.agent_name }}'
       inputs:
@@ -188,35 +189,38 @@ grain_name:
 ```
 
 :::info
-Note that in auto-generated blueprints, the __grain_name.spec.host.name__ is automatically published as a blueprint input, which the blueprint designer can use. As a best practice, it's recommended to remove the __host.name__ input once the blueprint is published to the catalog.
+Note that in auto-generated blueprints, the __grain_name.spec.agent.name__ is automatically published as a blueprint input, which the blueprint designer can use. As a best practice, it's recommended to remove the __agent.name__ input once the blueprint is published to the catalog.
 :::
 
 
 The following grains are available:
 * [Terraform](/blueprint-designer-guide/blueprints/terraform-grain)
+* [OpenTofu](/blueprint-designer-guide/blueprints/opentofu-grain)
 * [Helm](/blueprint-designer-guide/blueprints/helm-grain)
-* [CloudFormation](/blueprint-designer-guide/blueprints/cloudformation-grain)
 * [Kubernetes](/blueprint-designer-guide/blueprints/kubernetes-grain)
 * [Shell](/blueprint-designer-guide/blueprints/shell-grain)
 * [Ansible](/blueprint-designer-guide/blueprints/ansible-grain)
-* [CloudShell](/blueprint-designer-guide/blueprints/cloudshell-grain)
+* [CloudFormation](/blueprint-designer-guide/blueprints/cloudformation-grain)
 * [Blueprint](/blueprint-designer-guide/blueprints/blueprint-grain)
+* [CloudShell](/blueprint-designer-guide/blueprints/cloudshell-grain)
 
-### Source
+## source
+
 Sources are repositories storing IaC, CM or other configuration technology that will be utilized by Torque to launch and operate an environment. Torque supports multiple ways to define grain sources. 
 Sources can be defined in the following ways:
 
 __1. Direct link to a source control folder__:
 
 Composed from the repository URL followed by the folder structure leading to the folder where IaC code resides. For example:
+
 ```yaml 
 grains:
   aurora:
     kind: terraform
     spec:
       source:
-        store: my-repo
-        path: folder/my-app
+        store: my-repo # connected repository name
+        path: folder/my-app # path to module
 
 ```
 
@@ -235,6 +239,7 @@ grains:
 ```
 :::info
 In case your IaC code is not under folder in the repository, the path should be set as in the following example:
+
 ```yaml 
       source:
         store: web_servers
@@ -266,11 +271,13 @@ grains:
 * If "commit" is provided, Torque __will not__ track changes.
 :::
 
-### Agent
+## agent
+
 The ```agent``` defines the agent that will deploy the grain. While different grains behave differently, it's important to choose the right agent for a grain to make sure authentication, networking and configuration is all properly configured. Different grains in the same blueprint can use different agents to allow maximum flexibility during the orchestration processes.
 
 You can specify the agent in two ways:
 - Literally. For example:
+
 ```yaml 
 grains:
   # launch an RDS instance using Terraform
@@ -280,15 +287,16 @@ grains:
       agent:
         name: my-agent
  ``` 
+
 - Using an input of type "agent", which allows the environment end-user to select the agent to use from a dropdown list. For details, see the [blueprint yaml's inputs](/blueprint-designer-guide/blueprints/blueprints-yaml-structure#inputs) section.
+
 ```yaml 
 grains:
-  # launch an RDS instance using Terraform
   rds:
     kind: terraform
     spec:
       agent:
-        name: '{{ inputs.my_agent_ }}'
+        name: '{{ inputs.agent_name }}'
  ```  
 
 :::info
@@ -319,7 +327,10 @@ grains:
         service-account: torque-sa # Optional
  ```   
 
-You can add the ```nodeSelector``` section to your grain and specify the node labels you want the target node(s) to have. The nodeSelector and its labels will be applied on the pod specification. Kubernetes only schedules the pod onto nodes that have each of the labels you specify. For example:
+You can add the ```nodeSelector``` and/or ```pod-labels``` sections to your grain and specify the node labels you want the target node(s) to have. The nodeSelector and its labels will be applied on the pod specification. Kubernetes only schedules the pod onto nodes that have each of the labels you specify. 
+
+For example:
+
 ```yaml
 grains:
   nginx:
@@ -327,66 +338,58 @@ grains:
     spec: 
       source:
         ...
-      host:
+      agent:
         name:
         kubernetes:
           nodeSelector:
-          - app: torque
+            - app: torque
+          pod-labels:
+            - app: torque
 ```
 
-### Grain inputs & outputs
+## Grains inputs & outputs
 Inputs and outputs are used both in the blueprint level and in the grains level. Grains can use inputs and outputs to pass data between IaC components, validate information and eventually lead to reducing the amount of IaC components that needs to be maintained by the organization.
 
 In the below example, a Terraform deployment generates a connection string to a managed database that can then be utilized by the application itself using the ability to pass output from one grain as a input to the other.
+
 ```yaml 
 grains:
-  # launch an RDS instance using Terraform
   rds:
+    # launch an RDS instance using Terraform
     kind: terraform
     spec:
       ...
-	  ...
       outputs:
         - connection_string
 
   my_app_demo:
-	# Launcing k8s based microservices application using HELM
+    # launcing k8s based microservices application using HELM
     kind: helm
     depends-on: rds
-	...
-	...
+    spec:
+      ...
       inputs:
-        - connectionString: '{{ .grains.rds.outputs.connection_string }}'
+        - db.connectionString: '{{ .grains.rds.outputs.connection_string }}'
  ```    
 
-You can add the ```quick: true``` tag to outputs you wish to display in the __Quick Access__ section of the environment.
-```yaml 
-outputs:
-  default_output:
-    value: 'https://www.google.com:443'
-    quick: true
-```
-The above output will be displayed as follows:
-> ![Locale Dropdown](/img/quick-output.png)
-
-### Grain dependencies
+## Grains dependencies
 The need to deploy one IaC component before the other is common and usually required when 3rd party components, managed services and other teams need to provide the infrastructure. Using dependencies in the blueprint YAML Torque will evaluate and optimize the deployment process to make sure dependencies are respected and components with no dependencies will be deployed in parallel to maximize efficiency and reduce overall uptime.
 
 In the example below, 3 grain in the blueprint will be deployed in the following order: rds and redis will be deployed in parallel - and my_app will be deployed next, only in case of a successful deployment.
 
 ```yaml 
 grains:
-  # launch an RDS instance using Terraform
   rds:
+    # launch an AWS RDS instance using Terraform
     kind: terraform
 
 grains:
-  # launch an ElastiCache 
   redis:
-    kind: terraform
+    # launch an AWS ElastiCache using CloudFormation
+    kind: cloudformation
 
   my_app_demo:
-	# Launcing k8s based microservices application using HELM
+    # launcing K8s based microservices application using Helm
     kind: helm
     depends-on: rds, redis
  ```   
@@ -397,8 +400,7 @@ The ability to use outputs from specific grain usually requires the grain deploy
 :::
 
 
-
-### Torque Templating engine
+## Torque Templating Engine
 Templating engines are a great way to enrich the YAML format to allow extensibility points and text manipulations. Torque utilizes a GO-Lang style engine called [Shopify Liquid](https://shopify.github.io/liquid/) to allow dynamic injection of parameters and inputs as well as provider attribute values via reference of other attributes within the same YAML. 
 Example:
 * Insert Blueprint input from the user as a value for a Grain input. 
@@ -413,6 +415,7 @@ In the below example the [downcase](https://shopify.github.io/liquid/filters/dow
     kind: terraform
     spec:
       source:
+        store: assets
         path: s3
       agent:
         name: '{{ .inputs.agent_name }}'
@@ -422,15 +425,15 @@ In the below example the [downcase](https://shopify.github.io/liquid/filters/dow
 
 For details and examples of how to use the parameters from the parameter store inside blueprints, check [this article](/blueprint-designer-guide/blueprints/blueprints-yaml-structure#parameters).
 
-### Dynamic Attributes
+## Dynamic Attributes
 Blueprint designers might need extra details about the account, space or environment during the environment's orchestration. Torque provides dynamic attributes which are pre-defined parameters blueprints designers can use. The currently supported dynamic attributes are:
 
-- envId
-- blueprintName 
-- ownerEmail
-- environmentName
-- accountName
-- spaceName
+- `envId`
+- `blueprintName`
+- `ownerEmail`
+- `environmentName`
+- `accountName`
+- `spaceName`
 
 Here is an example of how it can be used:
 
@@ -446,18 +449,20 @@ The dynamic attributes calculation is case insensitive so you can use either "en
 :::
 
 
-### Parameters
+## parameters
 Torque's [Parameters](/admin-guide/params) store allows admins to set pre-defined account/space-level parameters. Blueprint designers can use the parameters in the blueprint YAML, instead of inputs if they don't want the environment end-user to provide the value, but also don't want to hard-code it in the blueprint.
 
-The syntax is: ```{{.params.param-value}}```
+The syntax is: ```{{ .params.param-value }}```
 
 The syntax is the same for both account and space level parameters. A space-level parameter will take precedence over an account-level parameter with the same name.
 
 ```yaml 
+grains:
   s3_bucket:
     kind: terraform
     spec:
       source:
+        store: assets
         path: s3
       agent:
         name: '{{ .inputs.agent_name }}'
@@ -465,22 +470,21 @@ The syntax is the same for both account and space level parameters. A space-leve
         - bucket_name: '{{ .params.my-bucket }}'
 ```
 
-### Environment Variables
+## Environment Variables
 In many cases, passing information through environment variables is required for IaC modules to properly execute with the right data in mind. The environment variables provided under a specific grain will be accessible only during the grain lifecycle of the specific grain and can be used as a specific string or to be derived from a blueprint input or other grain output. 
 
 ```yaml 
   s3_bucket:
     kind: 
     spec:
-    ...
-    ...
+      ...
       env-vars:
-      - VAR_NAME1: value1
-      - VAR_NAME2: '{{ .inputs.input_name }}'
-      - VAR_NAME3: '{{ .grains.vm.outputs.agent_name }}'
+        - VAR_NAME1: value1
+        - VAR_NAME2: '{{ .inputs.input_name }}'
+        - VAR_NAME3: '{{ .grains.vm.outputs.agent_name }}'
 ```
 
-### Disabling Auto-Retry
+## Disabling Auto-Retry
 In some situations, Torque will automatically retry to deploy failed grains. This behavior is usually very beneficial but it might not be suitable in all cases.
 In case you wish to exclude a specific grain from the auto-retry, include the following in the blueprint:
 
@@ -490,18 +494,72 @@ The auto-retry currently applies only to terraform grain. To learn more about au
 
 
 ```yaml 
-grain_name:
+grains:
+  s3:
     kind: terraform
     spec:
       source:
       ...
-      auto-retry: false  
+      auto-retry: false  # optional
 ```
 
 The auto-retry element is optional . If not present, it defaults to "true". Can be "true" or "false".
 
 
-### layout 
+## workspace-directories
+
+:::note
+The `workspace-directories` is supported only for Helm grains.
+:::
+
+The `workspace-directories` section allows you to specify a list of source repositories that will be checked out and made available in the workspace during the deployment process. These repositories can contain files that are required, such as configuration files, scripts, or any other supporting files.
+
+### Configuring Workspace Directories
+
+Within the `workspace-directories` section, you can specify one or more sources. Each source is defined as follows:
+
+```yaml
+grains:
+  app:
+    kind: helm
+    spec:
+      agent:  
+      ...
+      workspace-directories:
+        - source:
+            store: <connected repo name>
+            name: DIRECTORY_NAME # used to access the checked-out files in the workspace
+            tag: <tag> # can be replaced with branch: <branch name> or commit: <commit sha>
+```
+
+- `store`: The name of the store (repository) where the source files are located.
+- `name`: The name that will be used to access the checked-out files in the workspace. This name will be available as an environment variable during the execution of commands.
+- `tag`: The tag of the repository to be checked out. (can be replaced with `branch: <branch name>` or `commit: <commit sha>`)
+
+### Accessing Workspace Directories
+
+Taking Helm for example, during the execution of commands specified in the `commands` section, you can access the checked-out files from the workspace-directories using the environment variables that correspond to the `name` specified for each source.
+
+For example, if you have defined two workspace directories with the names `APP_CONFIG_REPO` and `APP_VALUES_REPO`, you can access their contents using the `${APP_CONFIG_REPO}` and `${APP_VALUES_REPO}` environment variables, respectively.
+
+```yaml
+grains:
+  app:
+    kind: helm
+    spec:
+      agent:
+      ...
+      commands:
+        - list && cp -R ${APP_CONFIG_REPO}/src/main/config ${WORK_DIR}
+        - list && cp -R ${APP_VALUES_REPO}/global/config ${WORK_DIR}
+```
+
+In the above example, the `cp` command copies files from the `src/main/config` directory of the `APP_CONFIG_REPO` repository and the `global/config` directory of the `APP_VALUES_REPO` repository into the `${WORK_DIR}` directory.
+
+
+In this case, the entire repository will be checked out, and the `name` specified (`ROOT_DIR`) can be used to access the root directory in the workspace.
+
+## layout 
 
 Layout is a separate yaml that will be referenced from the blueprint yaml like so:
 
@@ -510,8 +568,8 @@ spec_version: 2
 description: ...
 layout:
   source:
-    store:
-    path:
+    store: <connected repo>
+    path: <path to layout file>
   exclude-from-layout:  # optional
     - grain_name_1
     - grain_name_2

--- a/docs/blueprint-designer-guide/blueprints/blueprints-yaml-structure.md
+++ b/docs/blueprint-designer-guide/blueprints/blueprints-yaml-structure.md
@@ -509,7 +509,7 @@ The auto-retry element is optional . If not present, it defaults to "true". Can 
 ## workspace-directories
 
 :::note
-The `workspace-directories` is supported only for Helm grains.
+The `workspace-directories` is supported only for Helm grains at the moment.
 :::
 
 The `workspace-directories` section allows you to specify a list of source repositories that will be checked out and made available in the workspace during the deployment process. These repositories can contain files that are required, such as configuration files, scripts, or any other supporting files.


### PR DESCRIPTION
The `workspace-directories` section allows you to specify a list of source repositories that will be checked out and made available in the workspace during the deployment process. These repositories can contain files that are required, such as configuration files, scripts, or any other supporting files.
